### PR TITLE
Updated provider.tf.j2 as per update on terraform

### DIFF
--- a/templates/azure/provider.tf.j2
+++ b/templates/azure/provider.tf.j2
@@ -1,5 +1,4 @@
 provider "azurerm" {
-    version = "~>2.0"
     features {}
     subscription_id = var.subscription_id
     tenant_id       = var.tenant_id


### PR DESCRIPTION
Removed *version = "~>2.0"* from the provider block. It has been added under main.tf.j2 inside the required providers block.